### PR TITLE
Fix sitemap URL to use www.connorladly.com

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -78,10 +78,13 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe>`,
   css: ['~/assets/styles/main.css'],
   modules: ['@nuxtjs/tailwindcss', '@nuxtjs/sitemap'],
 
+  site: {
+    url: 'https://www.connorladly.com',
+  },
+
   sitemap: {
     // Automatically include all pages
     enabled: true,
-    hostname: 'https://connorladly.com',
     // Allow custom routes to be added via additionalPaths
     urls: [],
     // You can add custom routes by modifying this array:


### PR DESCRIPTION
## Summary
Configure site URL to use custom domain instead of Netlify auto-detected URL

## Changes
- Add `site.url` config set to `https://www.connorladly.com`
- Remove redundant `hostname` from sitemap config (it inherits from site.url)

## Why
The sitemap was using `https://connorladly-com.netlify.app/` but the site is hosted via reverse proxy at `https://www.connorladly.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)