### PR TITLE
feat: fix sitemap host, add canonicals & per-page SEO meta

### DIFF
--- a/composables/usePageSeo.ts
+++ b/composables/usePageSeo.ts
@@ -1,0 +1,29 @@
+import { withoutTrailingSlash } from 'ufo';
+
+const SITE_URL = 'https://www.connorladly.com';
+
+/**
+ * Sets a unique title + description for a page and emits an absolute canonical
+ * URL on the real domain. The absolute canonical is important because the site
+ * is also reachable at the Netlify deploy URL — pointing canonical at the
+ * primary domain prevents that copy being indexed as duplicate content.
+ */
+export function usePageSeo(meta: { title: string; description: string }) {
+  const route = useRoute();
+  const canonical =
+    route.path === '/'
+      ? `${SITE_URL}/`
+      : `${SITE_URL}${withoutTrailingSlash(route.path)}`;
+
+  useSeoMeta({
+    title: meta.title,
+    description: meta.description,
+    ogTitle: meta.title,
+    ogDescription: meta.description,
+    ogUrl: canonical,
+  });
+
+  useHead({
+    link: [{ rel: 'canonical', href: canonical }],
+  });
+}

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -97,17 +97,19 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe>`,
     },
   },
 
+  // Canonical site URL. Consumed by @nuxtjs/sitemap (so sitemap URLs use the
+  // real domain instead of the Netlify deploy URL) and by the per-page
+  // canonical tags. Override per-deploy with NUXT_PUBLIC_SITE_URL if needed.
+  site: {
+    url: 'https://www.connorladly.com',
+    name: 'Connor Ladly-Fredeen',
+  },
+
   sitemap: {
     // Automatically include all pages
     enabled: true,
-    hostname: 'https://connorladly.com',
     // Allow custom routes to be added via additionalPaths
     urls: [],
-    // You can add custom routes by modifying this array:
-    // urls: [
-    //   '/custom-route-1',
-    //   '/custom-route-2',
-    // ]
   },
 
   compatibilityDate: '2025-01-16',

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -1,3 +1,13 @@
+<script setup>
+import { usePageSeo } from '~/composables/usePageSeo';
+
+usePageSeo({
+  title: 'About | Connor Ladly-Fredeen',
+  description:
+    'About Connor Ladly-Fredeen — a director of engineering with 10+ years in tech, focused on scaling high-throughput systems and building happy, performant teams.',
+});
+</script>
+
 <template>
   <div class="prose mx-auto py-20">
     <h1>About Connor</h1>

--- a/pages/contact.vue
+++ b/pages/contact.vue
@@ -1,3 +1,13 @@
+<script setup>
+import { usePageSeo } from '~/composables/usePageSeo';
+
+usePageSeo({
+  title: 'Contact | Connor Ladly-Fredeen',
+  description:
+    'Get in touch with Connor Ladly-Fredeen — email, LinkedIn, Instagram, Bluesky, and Strava.',
+});
+</script>
+
 <template>
   <div class="prose mx-auto py-20">
     <h1>Contact</h1>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,3 +1,14 @@
+<script setup>
+import { usePageSeo } from '~/composables/usePageSeo';
+
+usePageSeo({
+  title:
+    'Connor Ladly-Fredeen | Startup Leader, Triathlete & Retired Ballet Dancer',
+  description:
+    'Personal website of Connor Ladly-Fredeen — director of engineering, triathlete, and retired ballet dancer. Background, projects, and how to get in touch.',
+});
+</script>
+
 <template>
   <div class="text-center py-20">
     <h1 class="text-4xl font-bold">

--- a/pages/projects.vue
+++ b/pages/projects.vue
@@ -1,3 +1,13 @@
+<script setup>
+import { usePageSeo } from '~/composables/usePageSeo';
+
+usePageSeo({
+  title: 'Projects | Connor Ladly-Fredeen',
+  description:
+    'Projects Connor Ladly-Fredeen is working on — high-throughput data systems, engineering team building, and endurance running goals.',
+});
+</script>
+
 <template>
   <div class="prose mx-auto py-20">
     <h1>Projects</h1>


### PR DESCRIPTION
## What

Fixes the SEO issues found in the audit (site-wide + main Nuxt pages). The `/lane-duck` app was already well-optimized and is untouched.

### 🔴 Sitemap pointed at the wrong host
The generated `sitemap.xml` listed `https://connorladly-com.netlify.app/...` because `@nuxtjs/sitemap` v7 reads `site.url`, which was unset (only the legacy, non-www `sitemap.hostname` was configured). Now sets `site: { url: 'https://www.connorladly.com' }`, so the sitemap uses the canonical domain and the build no longer warns `Sitemap Site URL missing`.

### 🔴 Duplicate-content risk from the Netlify subdomain
`connorladly-com.netlify.app` serves the whole site (HTTP 200) with no canonical. Every page now emits an **absolute** `<link rel="canonical">` on `https://www.connorladly.com`, so the netlify.app copy points back to the primary domain instead of competing with it.

### 🟠 No canonicals / duplicate titles on main pages
`/`, `/about`, `/projects`, `/contact` previously had **no canonical** and all shared the single global title + description. Added a small `usePageSeo` composable and gave each page a unique title + meta description.

## Verification

- `yarn generate` succeeds, no `Sitemap Site URL missing` warning
- `sitemap.xml` → all 4 URLs on `https://www.connorladly.com`
- Each page's built HTML has a unique `<title>`, unique `<meta name="description">`, and an absolute canonical to the www domain
- `yarn lint` and `yarn format:check` pass

## Not included (tracked separately)
- Hard redirect/`noindex` for the `*.netlify.app` host (Netlify dashboard setting — canonicals already mitigate)
- lane-duck timezone/data-freshness + stale sitemap `lastmod` (other repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
