### PR TITLE
feat: structured data + internal link to lane-duck (SEO)

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,4 +1,5 @@
 <script setup>
+import { useHead } from '#imports';
 import { usePageSeo } from '~/composables/usePageSeo';
 
 usePageSeo({
@@ -6,6 +7,38 @@ usePageSeo({
     'Connor Ladly-Fredeen | Startup Leader, Triathlete & Retired Ballet Dancer',
   description:
     'Personal website of Connor Ladly-Fredeen — director of engineering, triathlete, and retired ballet dancer. Background, projects, and how to get in touch.',
+});
+
+// Entity / site structured data — helps search engines understand who this site
+// is about. Uses the same social profiles linked on the contact page.
+useHead({
+  script: [
+    {
+      type: 'application/ld+json',
+      innerHTML: JSON.stringify({
+        '@context': 'https://schema.org',
+        '@graph': [
+          {
+            '@type': 'Person',
+            name: 'Connor Ladly-Fredeen',
+            url: 'https://www.connorladly.com',
+            jobTitle: 'Director of Engineering',
+            sameAs: [
+              'https://www.linkedin.com/in/connorladlyfredeen',
+              'https://www.instagram.com/connorlads',
+              'https://bsky.app/profile/connorladly.bsky.social',
+              'https://www.strava.com/athletes/64861889',
+            ],
+          },
+          {
+            '@type': 'WebSite',
+            name: 'Connor Ladly-Fredeen',
+            url: 'https://www.connorladly.com',
+          },
+        ],
+      }),
+    },
+  ],
 });
 </script>
 

--- a/pages/projects.vue
+++ b/pages/projects.vue
@@ -24,6 +24,14 @@ usePageSeo({
         <strong>Running Goals:</strong> Boston Marathon 2025 DONE. Up next:
         Tremblant IronMan 70.3, More marathons? We'll see...
       </li>
+      <li>
+        <strong>LaneDuck 🦆:</strong> A
+        <a href="https://www.connorladly.com/lane-duck"
+          >Toronto pool lane-swim schedule finder</a
+        >
+        that aggregates lane swim times across 370+ City of Toronto public
+        pools. Built with Python and FastAPI.
+      </li>
     </ul>
   </div>
 </template>


### PR DESCRIPTION
Follow-ups from the Search Console analysis:

- **Person + WebSite JSON-LD** on the homepage — the main site had no structured data (lane-duck does). Uses the social profiles from the contact page as `sameAs`.
- **LaneDuck listed on /projects** with a crawlable link — thickens the thin `/projects` page (Search Console shows it 'Crawled - currently not indexed') and gives Google an internal link to `/lane-duck`, which URL Inspection reports as 'URL is unknown to Google' (never crawled).

Verified: `yarn generate` OK, Person JSON-LD + lane-duck link present in output, `yarn lint` + `yarn format:check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)