### PR TITLE
chore: use www host for sitemap URLs in robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -4,5 +4,5 @@ User-agent: *
 Allow: /
 
 # Sitemaps
-Sitemap: https://connorladly.com/sitemap.xml
-Sitemap: https://connorladly.com/lane-duck/sitemap.xml
+Sitemap: https://www.connorladly.com/sitemap.xml
+Sitemap: https://www.connorladly.com/lane-duck/sitemap.xml


### PR DESCRIPTION
Switches the two `Sitemap:` lines in robots.txt from `https://connorladly.com/...` to `https://www.connorladly.com/...`, matching the canonical www host used by canonicals, `site.url`, and the sitemap contents.

Non-blocking (the Search Console domain property covers both hosts and both resolve) — purely for host consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)