### PR TITLE
fix: redirect dropped pages via public/_redirects

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,20 +2,5 @@
   publish = "dist"
   command = "yarn generate"
 
-# The About/Projects/Contact pages were folded into the single-page homepage.
-# Redirect the old paths to / so existing/indexed links don't 404. Revisit if
-# these sections are rebuilt as standalone pages later.
-[[redirects]]
-  from = "/about"
-  to = "/"
-  status = 301
-
-[[redirects]]
-  from = "/projects"
-  to = "/"
-  status = 301
-
-[[redirects]]
-  from = "/contact"
-  to = "/"
-  status = 301
+# Redirects live in public/_redirects (ships inside the publish dir, which is
+# more reliable than netlify.toml for this static Nuxt setup).

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,5 @@
+# Old pages folded into the single-page homepage. Redirect so indexed links
+# don't 404. Revisit if these sections are rebuilt as standalone pages.
+/about      /  301
+/projects   /  301
+/contact    /  301


### PR DESCRIPTION
The netlify.toml redirects weren't applied (old pages 404'd). Switches to public/_redirects, which ships in the publish dir and Netlify honors reliably.

Verified locally: _redirects present in .output/public. Removes the redundant netlify.toml redirect block.
