### PR TITLE
feat: host site directly on the VM, drop Netlify

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,71 @@
+name: Deploy
+
+# Push-to-deploy: build the static site and ship it to the connorladly-1 VM,
+# which serves it directly via nginx (see deploy.sh / deploy/nginx-default.conf).
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+# Never run two deploys at once; cancel an in-flight one if a newer push lands.
+concurrency:
+  group: deploy-production
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Build and deploy to VM
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Generate static site
+        run: yarn generate
+
+      - name: Package build
+        run: tar czf site.tar.gz -C .output/public .
+
+      - name: Add SSH key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.VM_SSH_PRIVATE_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -H "${{ vars.VM_HOST }}" >> ~/.ssh/known_hosts 2>/dev/null
+
+      - name: Upload build to VM
+        run: |
+          scp -i ~/.ssh/deploy_key site.tar.gz \
+            "${{ vars.VM_USER }}@${{ vars.VM_HOST }}:~/site.tar.gz"
+
+      - name: Swap into web root
+        run: |
+          ssh -i ~/.ssh/deploy_key "${{ vars.VM_USER }}@${{ vars.VM_HOST }}" '
+            set -e
+            WEBROOT=/var/www/connorladly
+            sudo rm -rf ${WEBROOT}.new
+            sudo mkdir -p ${WEBROOT}.new
+            sudo tar xzf ~/site.tar.gz -C ${WEBROOT}.new
+            sudo chown -R root:root ${WEBROOT}.new
+            sudo rm -rf ${WEBROOT}.old
+            [ -d ${WEBROOT} ] && sudo mv ${WEBROOT} ${WEBROOT}.old || true
+            sudo mv ${WEBROOT}.new ${WEBROOT}
+            sudo rm -rf ${WEBROOT}.old ~/site.tar.gz
+            echo deployed
+          '
+
+      - name: Verify site responds
+        run: |
+          code=$(curl -s -o /dev/null -w "%{http_code}" https://www.connorladly.com/)
+          echo "Homepage returned $code"
+          test "$code" = "200"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,9 +60,14 @@ yarn format:check  # Check formatting without making changes
 - **GitHub Actions** runs on PRs to master branch (.github/workflows/ci.yml)
 - CI checks: linting and formatting
 - **Deployment**: served directly by nginx on the `connorladly-1` GCP VM (no
-  Netlify). Run `./deploy.sh` to build locally and ship the static output to the
-  VM's web root (`/var/www/connorladly`). The build runs locally because the
-  f1-micro VM lacks the RAM to build Nuxt itself.
+  Netlify).
+  - **Push-to-deploy**: pushing to `master` triggers `.github/workflows/deploy.yml`,
+    which builds and ships the static output to the VM over SSH. Auth uses the
+    `VM_SSH_PRIVATE_KEY` repo secret with `VM_HOST` / `VM_USER` repo variables.
+  - **Manual**: `./deploy.sh` builds locally and ships the same way (useful for
+    out-of-band deploys). The build runs locally/in CI because the f1-micro VM
+    lacks the RAM to build Nuxt itself; the VM only serves static files.
+  - Web root on the VM: `/var/www/connorladly`.
 - The VM's nginx also serves the lane-duck app and `/api`. A reference copy of
   the server config lives in `deploy/nginx-default.conf`; the live file is
   `/etc/nginx/sites-available/default` on the VM.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,15 @@ yarn format:check  # Check formatting without making changes
 
 - **GitHub Actions** runs on PRs to master branch (.github/workflows/ci.yml)
 - CI checks: linting and formatting
-- **Deployment**: Netlify (automatic on push)
+- **Deployment**: served directly by nginx on the `connorladly-1` GCP VM (no
+  Netlify). Run `./deploy.sh` to build locally and ship the static output to the
+  VM's web root (`/var/www/connorladly`). The build runs locally because the
+  f1-micro VM lacks the RAM to build Nuxt itself.
+- The VM's nginx also serves the lane-duck app and `/api`. A reference copy of
+  the server config lives in `deploy/nginx-default.conf`; the live file is
+  `/etc/nginx/sites-available/default` on the VM.
+- Requires gcloud CLI on the `default` config (project `connorladlydotcom`) with
+  SSH access to the VM.
 
 ## Node Version
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# Deploy the static site to the connorladly-1 VM (nginx serves it directly).
+#
+# Builds locally with `yarn generate`, ships the output to the VM, and swaps it
+# into the nginx web root atomically. Build runs locally — the f1-micro VM does
+# not have the RAM to run the Nuxt build itself.
+#
+# Requires: gcloud CLI authed on the `default` config (connorladlydotcom), and
+# SSH access to the VM (gcloud compute ssh).
+#
+# Usage: ./deploy.sh
+set -euo pipefail
+
+INSTANCE="connorladly-1"
+ZONE="us-west1-b"
+WEBROOT="/var/www/connorladly"
+TARBALL="/tmp/connorladly-site.tar.gz"
+
+echo "==> Building static site (yarn generate)"
+yarn generate
+
+echo "==> Packaging .output/public"
+tar czf "$TARBALL" -C .output/public .
+
+echo "==> Uploading to $INSTANCE"
+gcloud compute scp "$TARBALL" "$INSTANCE:~/connorladly-site.tar.gz" --zone="$ZONE"
+
+echo "==> Swapping into $WEBROOT"
+gcloud compute ssh "$INSTANCE" --zone="$ZONE" --command="\
+  set -e; \
+  sudo rm -rf ${WEBROOT}.new && sudo mkdir -p ${WEBROOT}.new && \
+  sudo tar xzf ~/connorladly-site.tar.gz -C ${WEBROOT}.new && \
+  sudo chown -R root:root ${WEBROOT}.new && \
+  sudo rm -rf ${WEBROOT}.old && \
+  ( [ -d ${WEBROOT} ] && sudo mv ${WEBROOT} ${WEBROOT}.old || true ) && \
+  sudo mv ${WEBROOT}.new ${WEBROOT} && \
+  sudo rm -rf ${WEBROOT}.old ~/connorladly-site.tar.gz && \
+  echo 'deployed'"
+
+rm -f "$TARBALL"
+echo "==> Done. Live at https://www.connorladly.com"

--- a/deploy/nginx-default.conf
+++ b/deploy/nginx-default.conf
@@ -1,0 +1,86 @@
+##
+# connorladly.com — served statically from the VM.
+# Static site files live in /var/www/connorladly (deployed via deploy.sh).
+# lane-duck app + /api are served locally (see location blocks below).
+##
+
+server {
+	if ($host = connorladly.com) {
+        	return 301 https://www.$host$request_uri;
+    	} # managed by Certbot
+
+        root /var/www/connorladly;
+
+        index index.html index.htm;
+
+        server_name www.connorladly.com connorladly.com;
+
+        # Static single-page site. Clean URLs fall back to .html, then 404.
+        location / {
+                try_files $uri $uri/ $uri.html =404;
+        }
+
+        # Old pages folded into the homepage — keep indexed links alive.
+        location = /about    { return 301 https://www.connorladly.com/; }
+        location = /projects { return 301 https://www.connorladly.com/; }
+        location = /contact  { return 301 https://www.connorladly.com/; }
+
+        error_page 404 /404.html;
+        location = /404.html { internal; }
+
+        location /api/toronto-pools/ {
+                proxy_pass http://localhost:3000/;
+        }
+
+        # Static prerendered crawlable pool directory (regenerated each scrape)
+        location = /lane-duck/pools {
+                alias /home/connorladly-fredeen/lane-duck/pool_schedules.html;
+                add_header Content-Type text/html;
+        }
+        location = /lane-duck/beaches {
+                alias /home/connorladly-fredeen/lane-duck/beaches.html;
+                add_header Content-Type text/html;
+        }
+        location = /lane-duck/sitemap.xml {
+                alias /home/connorladly-fredeen/lane-duck/sitemap.xml;
+                types { } default_type application/xml;
+        }
+        # Redirect trailing-slash to canonical no-slash (was 500 due to alias+slash)
+        location = /lane-duck/ {
+                return 301 https://www.connorladly.com/lane-duck;
+        }
+        # Serve the OG image locally (otherwise falls through to the Netlify proxy)
+        location = /lane-duck/og-image.png {
+                alias /home/connorladly-fredeen/lane-duck/og-image.png;
+                add_header Content-Type image/png;
+        }
+	location ~ ^/lane-duck/?$ {
+	      alias /home/connorladly-fredeen/lane-duck/index.html;
+	      add_header Content-Type text/html;
+	}
+
+    listen [::]:443 ssl ipv6only=on; # managed by Certbot
+    listen 443 ssl; # managed by Certbot
+    ssl_certificate /etc/letsencrypt/live/connorladly.com/fullchain.pem; # managed by Certbot
+    ssl_certificate_key /etc/letsencrypt/live/connorladly.com/privkey.pem; # managed by Certbot
+    include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
+}
+
+server {
+    if ($host = www.connorladly.com) {
+        return 301 https://$host$request_uri;
+    } # managed by Certbot
+
+
+    if ($host = connorladly.com) {
+        return 301 https://www.$host$request_uri;
+    } # managed by Certbot
+
+
+	listen 80 default_server;
+	listen [::]:80 default_server;
+
+	server_name www.connorladly.com connorladly.com;
+    return 404; # managed by Certbot
+}

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,0 @@
-[build]
-  publish = "dist"
-  command = "yarn generate"
-
-# Redirects live in public/_redirects (ships inside the publish dir, which is
-# more reliable than netlify.toml for this static Nuxt setup).

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,5 +1,0 @@
-# Old pages folded into the single-page homepage. Redirect so indexed links
-# don't 404. Revisit if these sections are rebuilt as standalone pages.
-/about      /  301
-/projects   /  301
-/contact    /  301


### PR DESCRIPTION
## What

Serve the static site **directly from nginx on the `connorladly-1` VM** and drop Netlify.

## Why

The VM's nginx already fronted `www.connorladly.com` and proxied every request to `connorladly-com.netlify.app`. That meant:

- Visitors terminated at the single VM anyway, so they never got Netlify's edge CDN — we paid Netlify's complexity for none of its main benefit.
- All site traffic reached Netlify from the VM's **single IP**, tripping Netlify's per-IP rate limit → the intermittent **429s** (a few times/day, ~5 min each) that UptimeRobot kept flagging.
- A `netlify.app` duplicate-content domain to keep de-indexed.

Serving statically from nginx removes all three.

## Changes

- **nginx** (`deploy/nginx-default.conf`, applied live on the VM): `location /` now serves `/var/www/connorladly` via `try_files` instead of `proxy_pass` to Netlify. lane-duck + `/api` blocks unchanged.
- `/about`, `/projects`, `/contact` → `/` 301s moved from Netlify `_redirects` into nginx. **`netlify.toml` and `public/_redirects` removed.**
- **`deploy.sh`**: builds locally (`yarn generate`) and ships `.output/public` to the VM web root, swapping atomically. Build stays local — the f1-micro can't build Nuxt.
- `CLAUDE.md` deployment docs updated.

## Status

**Already cut over and live** — verified on production:

- Homepage `200`, **no Netlify headers** (served by VM directly)
- `/about` → `301` → `/`
- `/lane-duck` → `200` (unchanged)
- `robots.txt`, `sitemap.xml`, `404` all correct

Previous nginx config backed up on the VM at `/etc/nginx/sites-available/default.bak.20260806` — revert is a one-file copy + `nginx -t && systemctl reload nginx`.

## Trade-offs / follow-ups

- **Lost:** Netlify auto-deploy-on-push and PR deploy previews. Future deploys are `./deploy.sh`. (A GitHub Action deploy could restore push-to-deploy later if wanted.)
- Netlify project is still connected but no longer serving; safe to leave as a fallback or decommission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018L1fUKsZVhFAoSA85HM6TZ
