### PR TITLE
feat: fill booklist author/year for both books

### DIFF
--- a/pages/reading.vue
+++ b/pages/reading.vue
@@ -10,13 +10,21 @@ usePageSeo({
 // optional.
 const nowReading = [
   {
-    title: 'A Player of Games',
+    title: 'The Player of Games',
     author: 'Iain M. Banks',
+    year: '1988',
     note: 'The Culture series',
   },
 ];
 
-const read = [{ title: 'A Giant Leap', note: 'AI in healthcare' }];
+const read = [
+  {
+    title: 'A Giant Leap',
+    author: 'Robert Wachter',
+    year: '2026',
+    note: 'AI in healthcare',
+  },
+];
 </script>
 
 <template>


### PR DESCRIPTION
Fills the previously-omitted author/year fields on `/reading` with looked-up data:

- **The Player of Games** — Iain M. Banks (1988), the Culture series. *(Corrected the title from "A" to the actual "The Player of Games".)*
- **A Giant Leap** — Robert Wachter (2026), AI in healthcare.

Verified locally: lint, format:check, and generate pass; built HTML contains all fields. Auto-deploys on merge.
